### PR TITLE
Allow iterables to be passed in for merging

### DIFF
--- a/dictmerge.py
+++ b/dictmerge.py
@@ -1,3 +1,6 @@
+import collections
+
+
 def dictmerge(*dicts, **kwargs):
     """
     Merges an arbitrary number of dicts and kwargs into a single (new) dict.
@@ -14,6 +17,10 @@ def dictmerge(*dicts, **kwargs):
     """
     result = {}
     for d in dicts:
-        result.update(d)
+        if isinstance(d, collections.Mapping):
+            result.update(d)
+        elif isinstance(d, collections.Iterable):
+            for e in d:
+                result.update(e)
     result.update(kwargs)
     return result


### PR DESCRIPTION
This is a pull request for #1 by making use of the abstract base classes in the collections module. For dictionaries and other mapping objects, use `update()` and for iterable objects, iterate and `update()`.
